### PR TITLE
Add documentation for OAuth scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,5 @@ git push
 
 - Add the app's subdomain to the Rakefile. This will cause `rake` to pull docs from that app.
 - Add the app's `include` file to `index.md`'s YAML frontmatter. This will cause the docs to be rendered on the page.
+- Add a corresponding OAuth scope to `api.planningcenteronline.com` and add an entry to the "Scopes" table in `index.md`
 - Run "Publishing Docs" above

--- a/source/index.md
+++ b/source/index.md
@@ -69,6 +69,19 @@ We will honor refresh tokens for up to 1 year after the date its associated acce
 
 We have an example Ruby/Sinatra app showing how to obtain and use access tokens and refresh tokens at [github.com/planningcenter/pco_api_oauth_example](https://github.com/planningcenter/pco_api_oauth_example).
 
+### Scopes
+
+Each PCO app is a distinct [OAuth scope](http://tools.ietf.org/html/rfc6749#section-3.3).
+
+
+| App | Scope|
+|-----|------|
+| People | people |
+| Services | services |
+| Check-ins | check_ins |
+
+When authorizing, you can request scopes using the `scope` parameter. The value should be a space-separated list of scopes.
+
 # JSON API
 
 This API is built to conform to the [JSON API](http://jsonapi.org/) 1.0 specification.


### PR DESCRIPTION
Although People and Services are self-evident, Check-ins can be a bit surprising since it requires an underscore, not a dash.  (https://github.com/planningcenter/developers/issues/123)

Looks like Giving doesn't have a scope yet (https://github.com/ministrycentered/api/blob/master/config/initializers/doorkeeper.rb#L54)

![image](https://cloud.githubusercontent.com/assets/2231765/12094301/d4b1d0b6-b2d5-11e5-94bf-e3bb9de52212.png)
