### PR TITLE
Update Oauth authoriztion instructions

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -97,7 +97,11 @@ Each PCO app is a distinct [OAuth scope](http://tools.ietf.org/html/rfc6749#sect
 | Services | services |
 | Check-ins | check_ins |
 
+Authorization URL is [https://api.planningcenteronline.com/oauth/authorize](https://api.planningcenteronline.com/oauth/authorize)
+Token URL is [https://api.planningcenteronline.com/oauth/token](https://api.planningcenteronline.com/oauth/token)
 When authorizing, you can request scopes using the `scope` parameter. The value should be a space-separated list of scopes.
+The value for `response_type` should be `code`
+
 
 # JSON API
 


### PR DESCRIPTION
Added URLs for authorization and token. 
Value for "response_type" parameter when authorizing needs to be 'code'
